### PR TITLE
chore: add ESM entrypoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msteams-react-base-component",
-  "version": "2.1.0-preview4",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1255,6 +1255,17 @@
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -2118,9 +2129,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "msteams-react-base-component",
   "version": "2.1.0",
   "description": "React helper components for Microsoft Teams apps",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "types": "lib/cjs/index.d.ts",
   "scripts": {
     "prepublishOnly ": "npm run clean && npm run build",
-    "build": "node_modules/.bin/tsc -p .",
-    "clean": "rm -rf lib",
-    "lint": "./node_modules/.bin/eslint ./src/**/*.tsx"
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig.es.json",
+    "clean": "rimraf lib",
+    "lint": "eslint ./src/**/*.tsx"
   },
   "keywords": [
     "react",
@@ -50,6 +51,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "rimraf": "^3.0.2",
     "typescript": "^3.9.2"
   },
   "dependencies": {},

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "module": "esnext",
+    "outDir": "./lib/esm"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "jsx": "react",
     "declaration": true,
     "sourceMap": false,
-    "outDir": "./lib",
+    "outDir": "./lib/cjs",
     "rootDir": "./src",
     "removeComments": false
   }


### PR DESCRIPTION
This PR adds a separate build to target ES modules (https://docs.skypack.dev/package-authors/package-checks#esm). This is super important as an existing Common JS build prevents tree shaking of Fluent UI, https://github.com/microsoft/fluentui/issues/12953#issuecomment-716827309.

With changes in this PR we will ship both Common JS and ESM builds.

