### PR TITLE
fix: use userAgent to detect Teams desktop client

### DIFF
--- a/src/useTeams.ts
+++ b/src/useTeams.ts
@@ -16,6 +16,7 @@ export const checkInTeams = (): boolean => {
     }
 
     if ((window.parent === window.self && (window as any).nativeInterface) ||
+        window.navigator.userAgent.includes('Teams/') ||
         window.name === "embedded-page-container" ||
         window.name === "extension-tab-frame") {
         return true;


### PR DESCRIPTION
I noticed that `window.nativeInterface` is not always exposed (or at least, it's not exposed for an application running in an iFrame in Teams), but that the `userAgent` exposes some hints that the application is embedded in the Electron client.

You might know better than me whether this will remain a suitable prediction method, but I figured I'd contribute it back anyway!